### PR TITLE
[BW] Avoid crashes in prepare_simulator action

### DIFF
--- a/lib/fastlane/plugin/stream_actions/actions/prepare_simulator.rb
+++ b/lib/fastlane/plugin/stream_actions/actions/prepare_simulator.rb
@@ -2,12 +2,22 @@ module Fastlane
   module Actions
     class PrepareSimulatorAction < Action
       def self.run(params)
-        version_set = params[:device].include?('(')
-        sim = FastlaneCore::Simulator.all.detect do |d|
-          params[:device] == (version_set ? "#{d.name} (#{d.os_version})" : d.name)
+        simulators = FastlaneCore::Simulator.all
+        version_provided = params[:device] =~ /\((\d+\.)?(\d+\.)?(\*|\d+)\)/
+        sim = if version_provided
+                simulators.detect { |d| "#{d.name} (#{d.os_version})" == params[:device] }
+              else
+                simulators.filter { |d| d.name == params[:device] }.max_by(&:os_version)
+              end
+
+        if sim.nil?
+          simulators.map! { |d| version_provided ? "#{d.name} (#{d.os_version})" : d.name }
+          UI.user_error!("Simulator #{params[:device]} not found \nAvailable simulators: \n#{simulators.join("\n")}")
+        else
+          sim.reset if params[:reset]
+          sh("xcrun simctl bootstatus #{sim.udid} -b")
+          UI.success("Simulator #{sim.name} (#{sim.os_version}) is ready")
         end
-        sim.reset if params[:reset]
-        sh("xcrun simctl bootstatus #{sim.udid} -b")
       end
 
       #####################################################

--- a/lib/fastlane/plugin/stream_actions/version.rb
+++ b/lib/fastlane/plugin/stream_actions/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
   module StreamActions
-    VERSION = "0.2.0"
+    VERSION = "0.2.1"
   end
 end

--- a/spec/fastlane_prepare_simulator_spec.rb
+++ b/spec/fastlane_prepare_simulator_spec.rb
@@ -7,7 +7,7 @@ describe Fastlane do
         result = described_class.new.parse("lane :test do
           prepare_simulator(device: '#{sim_name}')
         end").runner.execute(:test)
-        expect(result).not_to be_empty
+        expect(result).to be(true)
       end
 
       it 'verifies that simulator with version can be prepared' do
@@ -15,7 +15,7 @@ describe Fastlane do
         result = described_class.new.parse("lane :test do
           prepare_simulator(device: '#{sim_name} (#{sim.os_version})')
         end").runner.execute(:test)
-        expect(result).not_to be_empty
+        expect(result).to be(true)
       end
 
       it 'verifies that simulator can be reset' do
@@ -23,6 +23,20 @@ describe Fastlane do
 
         described_class.new.parse("lane :test do
           prepare_simulator(device: '#{sim_name}', reset: true)
+        end").runner.execute(:test)
+      end
+
+      it 'raises an error after providing a wrong name of the simulator' do
+        expect(Fastlane::UI).to receive(:user_error!)
+        described_class.new.parse("lane :test do
+          prepare_simulator(device: 'Google Pixel 4')
+        end").runner.execute(:test)
+      end
+
+      it 'raises an error after providing a wrong version of the simulator' do
+        expect(Fastlane::UI).to receive(:user_error!)
+        described_class.new.parse("lane :test do
+          prepare_simulator(device: '#{sim_name} (0.42)')
         end").runner.execute(:test)
       end
     end


### PR DESCRIPTION
## Description

**Then** prepare_simulator action crashed when faced with unexpected Simulator names and/or versions
**Now** it should not