### PR TITLE
Create an UpdateCopyrightAction action

### DIFF
--- a/lib/fastlane/plugin/stream_actions/actions/update_copyright.rb
+++ b/lib/fastlane/plugin/stream_actions/actions/update_copyright.rb
@@ -1,0 +1,54 @@
+module Fastlane
+  module Actions
+    class UpdateCopyrightAction < Action
+      def self.run(params)
+        new_year = Time.now.year.to_s
+
+        ext = '*.{swift,h,strings,pbxproj}'
+        source_files = Dir.glob(File.join(params[:path], '**', ext)).reject do |f|
+          params[:ignore].any? { |dir| f.include?(dir) }
+        end
+
+        source_files.each do |file_path|
+          old_content = File.read(file_path)
+          match = old_content.match(/Copyright © (\d{4}) Stream.io/)
+          next if !match || match[1] == new_year
+
+          old_year = match[1]
+          new_content = old_content.gsub("Copyright © #{old_year}", "Copyright © #{new_year}")
+
+          File.write(file_path, new_content)
+          UI.success("Updated copyright year in #{File.basename(file_path)}")
+        end
+      end
+
+      #####################################################
+      # @!group Documentation
+      #####################################################
+
+      def self.description
+        'Updates copyright headers in source files'
+      end
+
+      def self.available_options
+        [
+          FastlaneCore::ConfigItem.new(
+            key: :path,
+            description: 'A path to search for files to update',
+            default_value: '.'
+          ),
+          FastlaneCore::ConfigItem.new(
+            key: :ignore,
+            description: 'The folders to ignore',
+            is_string: false,
+            default_value: []
+          )
+        ]
+      end
+
+      def self.supported?(_platform)
+        [:ios].include?(platform)
+      end
+    end
+  end
+end

--- a/lib/fastlane/plugin/stream_actions/version.rb
+++ b/lib/fastlane/plugin/stream_actions/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
   module StreamActions
-    VERSION = '0.3.25'
+    VERSION = '0.3.26'
   end
 end


### PR DESCRIPTION
# Test

1. Clone repo
2. Check out the branch
3. Update `Pluginfile` in the main repo:
```ruby
gem 'fastlane-plugin-stream_actions', path: 'path/to/fastlane-plugin-stream_actions'
```
4. Run bundle install
5. Create new lane:
```ruby
lane :copyright do
  update_copyright(ignore: [derived_data_path, source_packages_path])
end
```
6. Run new lane:
```ruby
bundle exec fastlane copyright
```