### PR TITLE
Add an action to check if the foundation framework is required

### DIFF
--- a/lib/fastlane/plugin/stream_actions/actions/check_foundation.rb
+++ b/lib/fastlane/plugin/stream_actions/actions/check_foundation.rb
@@ -1,0 +1,111 @@
+module Fastlane
+  module Actions
+    class CheckFoundationAction < Action
+      def self.run(params)
+        errors = []
+        Dir.glob("#{params[:path]}/**/*.swift") do |file|
+          next if params[:ignore].any? { |path| file.include?(path) } || !File.file?(file)
+
+          content = File.read(file)
+          unless content.match?(/import (Foundation|SwiftUI|UIKit)/)
+            detected_keywords = scan(content)
+            unless detected_keywords.empty?
+              UI.error("#{file} needs to `import Foundation`. Detected keywords: #{detected_keywords}")
+              errors << { file: file, keywords: detected_keywords }
+            end
+          end
+        end
+
+        errors.empty? ? UI.success('Check passed ✅') : UI.user_error!('Check failed 🛑')
+      end
+
+      def self.scan(source_code)
+        foundation_keywords = %w[
+          Date
+          URL
+          Data
+          JSONDecoder
+          JSONEncoder
+          URLSession
+          DispatchQueue
+          OperationQueue
+          FileManager
+          Bundle
+          ProcessInfo
+          Calendar
+          DateFormatter Locale
+          NotificationCenter
+          NSCoder
+          NSUserDefaults
+          Operation
+          Progress
+          Timer
+          URLRequest
+          URLResponse
+          RunLoop
+          TimeZone
+          FileHandle
+          NSFileManager
+          NSFileHandle
+          NSFileVersion
+          NSRunLoop
+          NSTimeZone
+          NSProgress
+          NSTimer
+          NSRegularExpression
+          NSSortDescriptor
+          NSString
+          NSArray
+          NSDictionary
+          NSSet
+          NSIndexSet
+          NSCalendar
+          NSDateFormatter
+          NSLocale
+          NSDate
+          NSData
+          NSURL
+          NSError
+          NSUUID
+        ]
+
+        space_prefix = ' ' # To reduce false positives
+        found_keywords = []
+        source_code.each_line do |line|
+          next if line.include?('//') # To skip comments
+
+          found_keywords += foundation_keywords.select { |keyword| line.include?("#{space_prefix}#{keyword}") }
+        end
+
+        found_keywords.uniq
+      end
+
+      #####################################################
+      # @!group Documentation
+      #####################################################
+
+      def self.description
+        'Check if a swift file requires importing the Foundation framework'
+      end
+
+      def self.available_options
+        [
+          FastlaneCore::ConfigItem.new(
+            key: :path,
+            description: 'The path to the source code'
+          ),
+          FastlaneCore::ConfigItem.new(
+            key: :ignore,
+            description: 'An array of files or paths that should be ignored',
+            is_string: false,
+            default_value: []
+          )
+        ]
+      end
+
+      def self.supported?(_platform)
+        [:ios].include?(platform)
+      end
+    end
+  end
+end


### PR DESCRIPTION
### 🔗 Issue Links

Resolve https://github.com/GetStream/ios-issues-tracking/issues/857

### 🎯 Goal

- Create an action to catch missing `Foundation` imports

### 🎤 Showcase

- Currently on SwiftUI:
![Screenshot 2024-06-12 at 4 18 20 PM](https://github.com/GetStream/fastlane-plugin-stream_actions/assets/20794991/919fcb87-da88-4adb-bb75-e4063dd59086)

- And after removing `import Foundation` in `ChatClient+Extensions.swift`:
![Screenshot 2024-06-12 at 4 15 48 PM](https://github.com/GetStream/fastlane-plugin-stream_actions/assets/20794991/c5d35c10-4ffd-40a5-b6a5-c90ebf07ba06)

### 🧪 Testing notes

1. Pull this repo and checkout to the current branch
2. In the main repo, open the `Pluginfile` and replace the version with path to the cloned repo
3. Run `bundle install` in the main repo
4. Add a new lane to the `Fastfile`, e.g.:
```ruby
lane :verify_foundation_framework do
  check_foundation(
    path: 'Sources',
    ignore: ['StreamChatSwiftUI/StreamSwiftyGif/', 'StreamChatSwiftUI/StreamNuke/']
  )
end
```
5. Run the new lane:
```
bundle exec fastlane verify_foundation_framework
```

### 🎁 Meme

![gif](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExMmhwZHpncGF0NnExZjQwYjQ4b2drZ3k5aTM5Z2wxdnJnYTNyMG42dCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/JrgKnSlwmAKoiBENoS/giphy.gif)
